### PR TITLE
Build on win32

### DIFF
--- a/shared/easy.h
+++ b/shared/easy.h
@@ -253,7 +253,7 @@ void splice(InputBuffer *buffer, char *string, bool addString) { //if false will
     
     while(*at) {
         
-        if(addString > 0) { //adding
+        if(addString) { //adding
             
             if(buffer->length < (sizeof(buffer->chars) - 1)) {
                 

--- a/shared/easy_array.h
+++ b/shared/easy_array.h
@@ -258,7 +258,7 @@ void *getElement(Array_Dynamic *array, unsigned int absIndex) {
     
     void *elm = 0;
     PoolInfo info = getPoolInfo(array, absIndex);
-    if(info.pool && info.indexAt < (info.pool->indexAt) && index >= 0 && isElmValid(info.pool, info.indexAt)) {
+    if(info.pool && info.indexAt < (info.pool->indexAt) && info.indexAt >= 0 && isElmValid(info.pool, info.indexAt)) {
         
         elm = info.pool->memory + (info.indexAt*array->sizeofType);
     }

--- a/shared/easy_font.h
+++ b/shared/easy_font.h
@@ -35,9 +35,9 @@ FontSheet *createFontSheet(Font *font, int firstChar, int endChar)
     sheet->minText = firstChar;
     sheet->maxText = endChar;
     sheet->next = 0;
-    int bitmapW = FONT_SIZE;
-    int bitmapH = FONT_SIZE;
-    int numOfPixels = bitmapH*bitmapW;
+    const int bitmapW = FONT_SIZE;
+    const int bitmapH = FONT_SIZE;
+    const int numOfPixels = bitmapH*bitmapW;
     unsigned char temp_bitmap[numOfPixels]; //bakefontbitmap is one byte per pixel. 
     
     //TODO: use platform file io functions instead. 

--- a/src/build.bat
+++ b/src/build.bat
@@ -1,0 +1,3 @@
+..\bin\ctime -begin test.ctm
+cl /DDESKTOP=1 /DNOMINMAX /I../shared /I../libs/gl3w /IE:/include /Zi main.cpp ../libs/gl3w/GL/gl3w.cpp E:\lib\SDL2.lib E:\lib\SDL2main.lib opengl32.lib shlwapi.lib /Fe../bin/Fitris.exe /link /SUBSYSTEM:WINDOWS
+..\bin\ctime -end test.ctm

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1110,4 +1110,5 @@ int main(int argc, char *args[]) {
     }
     easyOS_endProgram(&appInfo);
 	}
+    return 0;
 }


### PR DESCRIPTION
This is pretty rough code, but it works on my machine.  There are still
several errors in the win32 section of easy_files due to many functions
in the windows api not handling '..' in the file path.  However, most of
these code paths are not currently used.  This at least provides an
example of how to fix those in the future.

The build.bat script will need to be modified with the SDL library and
include directories on your machine.